### PR TITLE
Add naming authority information to dist metadata

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,5 +1,6 @@
 {
     "name": "File::Zip",
+    "auth": "github:azawawi",
     "license" : "MIT",
     "version": "*",
     "perl": "6.c",


### PR DESCRIPTION
This information aids tools such as `zef` in tracking a dist's provenance and helps downstream users of a dist specify exactly which dist they want to use.  This change should help mitigate an issue whereby this dist shares the same name as another dist, however that dist is preferred by `zef` when users install via the name.  In other words, if someone runs

```
zef install File::Zip
```

they won't have this dist installed, they will have the more recent dist with the same name installed and this causes issues because the dists use separate APIs.  For more information about this problem see:

  - https://github.com/azawawi/raku-selenium-webdriver/issues/27
  - https://github.com/ugexe/zef/issues/553

The addition of the naming authority information will then allow other projects relying on this dist (e.g.
[`Selenium::WebDriver`](https://github.com/azawawi/raku-selenium-webdriver)) to specify the required upstream `File::Zip` dependency more exactly and hence save downstream users from wondering why `File::Zip` has a different API to what they expect.