### PR TITLE
Replace rakudobrew with rakubrew in AppVeyor config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,12 +6,14 @@ install:
   - '"C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64'
   - choco install strawberryperl
   - SET PATH=C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin;%PATH%
-  - git clone https://github.com/tadzik/rakudobrew %USERPROFILE%\rakudobrew
-  - SET PATH=%USERPROFILE%\rakudobrew\bin;%PATH%
-  - rakudobrew build moar 2016.03
-  - rakudobrew build zef
+  - curl https://rakubrew.org/install-on-cmd.bat -o install-on-cmd.bat && install-on-cmd.bat
+  - SET PATH=C:\rakubrew\bin;%PATH%
+  - 'FOR /F "delims=" %%i IN (''rakubrew home'') DO SET PATH=%%i/shims;%PATH%'
+  - rakubrew mode shim
+  - rakubrew download
+  - rakubrew build zef
   - cd %APPVEYOR_BUILD_FOLDER%
-  - zef --verbose --depsonly install .
+  - zef --verbose --deps-only install .
 
 build: off
 


### PR DESCRIPTION
... so that CI works on this platform work again.

Note that rakudobrew no longer exists and has been replaced by [rakubrew](https://rakubrew.org/).

This pull request is submitted in the hope that it is helpful. If you want anything changed, please just let me know and I'll be happy to update and resubmit as necessary.