### PR TITLE
Set version metadata to a semantic version number

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "name": "File::Zip",
     "license" : "MIT",
-    "version": "*",
+    "version": "0.0.1",
     "perl": "6.c",
     "description": "Perl 6 API to the ZIP file format",
     "depends": [


### PR DESCRIPTION
The current version information is simply `*` and is understood by `zef` as being effectively 0, hence another dist also by the name of `File::Zip` is found and installed (note that [it's likely that in the future such version strings will no longer be accepted by `zef` at all](https://github.com/ugexe/zef/issues/553)).

Because the version number is effectively 0, this causes problems with [`Selenium::WebDriver` not being able to install the correct `File::Zip` dist](https://github.com/azawawi/raku-selenium-webdriver/issues/27).

This change will help rectify that issue by the version string now being a non-wildcard character (see also #7 for another change which will help downstream modules be able to find this version of `File::Zip`).  The version number given here is a lower bound for the version information and thus is an attempt to be more Raku standards-compliant. Also, if my other recent pull requests (#7, #8, #9) are also merged after this one, then one could create a release with a later version number thus eventually being able to patch the situation for downstream distributions and code.